### PR TITLE
vscode設定: phpバージョンの指定をやめる

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
 	"editor.detectIndentation": false, // インデント構成の検知を無効化
 	"editor.insertSpaces": false, // タブを使用する
-	"intelephense.environment.phpVersion": "8.0.21", // PMMPのバージョンに合わせる
 	"editor.tabCompletion": "on",
 	"emmet.excludeLanguages": [ // HTMLやcssが書きやすくなる拡張機能らしいですが、pmmpの場合はほぼ使わないので無効化(勝手に展開されて邪魔)
 		"markdown",


### PR DESCRIPTION
今までは`8.0`だったけれど
使用する人が自由にできるようにする

(使用先のリポジトリで指定するか、ユーザー設定を引き継ぐか)